### PR TITLE
Adds element components as per University guidelines. Closes #9

### DIFF
--- a/src/elements/_LibraryContactInfo.vue
+++ b/src/elements/_LibraryContactInfo.vue
@@ -14,8 +14,8 @@
 
 <script>
 /**
- * Used to show the University’s copyright notice, including the current year
- * (“© 20xx The Trustees of Princeton University”) in the footer.
+ * Used to show Library's contact information, including address and phone, is
+ * clear and in the footer.
  */
 export default {
   name: "LibraryContactInfo",

--- a/src/elements/_LibraryContactInfo.vue
+++ b/src/elements/_LibraryContactInfo.vue
@@ -1,0 +1,53 @@
+<template>
+  <component :is="type" class="library-contact">
+    <div itemscope itemtype="http://schema.org/Organization">
+      <span itemprop="name">Princeton University Library</span> 
+      <div itemscope itemtype="http://schema.org/PostalAddress">
+        <span itemprop="streetAddress">One Washington Road</span> <br>
+        <span itemprop="addressLocality">Princeton</span>, <span itemprop="addressRegion">NJ</span> <span itemprop="postalCode">08544</span> <span itemprop="addressCountry">USA</span>
+      </div>
+      <span itemprop="telephone"><a href="tel:1-609-258-1470">(609) 258-1470</a></span>
+    </div>
+    <!-- icons (facebook, twitter, govdocs, friends) -->
+  </component>
+</template>
+
+<script>
+/**
+ * Used to show the University’s copyright notice, including the current year
+ * (“© 20xx The Trustees of Princeton University”) in the footer.
+ */
+export default {
+  name: "LibraryContactInfo",
+  status: "review",
+  release: "1.0.0",
+  type: "Element",
+  props: {
+    /**
+     * The html element name used for the wrapper.
+     */
+    type: {
+      type: String,
+      default: "",
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.library-contact {
+  @include reset;
+  @include stack-space($space-base);
+  font-family: $font-family-heading;
+  font-size: $font-size-x-small;
+  line-height: $line-height-heading;
+  color: $color-rich-black;
+}
+</style>
+
+
+<docs>
+  ```jsx
+  <library-contact-info type="div"></library-contact-info>
+  ```
+</docs>

--- a/src/elements/_UniversityAccessibility.vue
+++ b/src/elements/_UniversityAccessibility.vue
@@ -6,8 +6,7 @@
 
 <script>
 /**
- * Used to show the University’s copyright notice, including the current year
- * (“© 20xx The Trustees of Princeton University”) in the footer.
+ * Used to show the University’s Accessibility site in the footer.
  */
 export default {
   name: "UniversityAccessibility",

--- a/src/elements/_UniversityAccessibility.vue
+++ b/src/elements/_UniversityAccessibility.vue
@@ -1,0 +1,45 @@
+<template>
+  <component :is="type" class="accessibility">
+    <a href="https://accessibility.princeton.edu/">Accessibility</a>
+  </component>
+</template>
+
+<script>
+/**
+ * Used to show the University’s copyright notice, including the current year
+ * (“© 20xx The Trustees of Princeton University”) in the footer.
+ */
+export default {
+  name: "UniversityAccessibility",
+  status: "review",
+  release: "1.0.0",
+  type: "Element",
+  props: {
+    /**
+     * The html element name used for the wrapper.
+     */
+    type: {
+      type: String,
+      default: "",
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.accessibility {
+  @include reset;
+  @include stack-space($space-base);
+  font-family: $font-family-heading;
+  font-size: $font-size-x-small;
+  line-height: $line-height-heading;
+  color: $color-rich-black;
+}
+</style>
+
+
+<docs>
+  ```jsx
+  <university-accessibility type="span"></university-accessibility>
+  ```
+</docs>

--- a/src/elements/_UniversityCopyright.vue
+++ b/src/elements/_UniversityCopyright.vue
@@ -1,0 +1,45 @@
+<template>
+  <component :is="type" class="copyright">
+    &copy; {{ new Date().getFullYear() }} The Trustees of Princeton University
+  </component>
+</template>
+
+<script>
+/**
+ * Used to show the University’s copyright notice, including the current year
+ * (“© 20xx The Trustees of Princeton University”) in the footer.
+ */
+export default {
+  name: "UniversityCopyright",
+  status: "review",
+  release: "1.0.0",
+  type: "Element",
+  props: {
+    /**
+     * The html element name used for the wrapper.
+     */
+    type: {
+      type: String,
+      default: "",
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.copyright {
+  @include reset;
+  @include stack-space($space-base);
+  font-family: $font-family-heading;
+  font-size: $font-size-x-small;
+  line-height: $line-height-heading;
+  color: $color-rich-black;
+}
+</style>
+
+
+<docs>
+  ```jsx
+  <university-copyright type="span"></university-copyright>
+  ```
+</docs>

--- a/src/elements/_UniversityLogo.vue
+++ b/src/elements/_UniversityLogo.vue
@@ -1,13 +1,13 @@
 <template>
   <component :is="type" class="university-logo">
-    <svg-icon name="university-logo" ariaLabel="Princeton University" width="200px"></svg-icon>
+    <a href="https://princeton.edu"><svg-icon name="university-logo" ariaLabel="Princeton University" width="200px"></svg-icon></a>
   </component>
 </template>
 
 <script>
 /**
- * Used to show the University’s copyright notice, including the current year
- * (“© 20xx The Trustees of Princeton University”) in the footer.
+ * Used to identify that the site is a Princeton University site in the footer
+ * and links to princeton.edu.
  */
 export default {
   name: "UniversityLogo",

--- a/src/elements/_UniversityLogo.vue
+++ b/src/elements/_UniversityLogo.vue
@@ -1,0 +1,45 @@
+<template>
+  <component :is="type" class="university-logo">
+    <svg-icon name="university-logo" ariaLabel="Princeton University" width="200px"></svg-icon>
+  </component>
+</template>
+
+<script>
+/**
+ * Used to show the University’s copyright notice, including the current year
+ * (“© 20xx The Trustees of Princeton University”) in the footer.
+ */
+export default {
+  name: "UniversityLogo",
+  status: "review",
+  release: "1.0.0",
+  type: "Element",
+  props: {
+    /**
+     * The html element name used for the wrapper.
+     */
+    type: {
+      type: String,
+      default: "",
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.accessibility {
+  @include reset;
+  @include stack-space($space-base);
+  font-family: $font-family-heading;
+  font-size: $font-size-x-small;
+  line-height: $line-height-heading;
+  color: $color-rich-black;
+}
+</style>
+
+
+<docs>
+  ```jsx
+  <university-logo type="div"></university-logo>
+  ```
+</docs>


### PR DESCRIPTION
These are set as private components (indicated by _ in filename) and will not display in the docs since these will only need to be used by design system developers. We will create a footer pattern which will use these elements.