### PR TITLE
Adds input-select, input-checkbox, and input-radio elements

### DIFF
--- a/src/elements/ChoiceInput.vue
+++ b/src/elements/ChoiceInput.vue
@@ -1,20 +1,32 @@
 <template>
   <component :is="wrapper" class="input">
     <label v-if="label">{{ label }}</label>
-    <input
+    <!-- type = select -->
+    <select v-if="isSelect"
       :id="id"
-      :disabled="disabled"
-      :type="type"
-      :hover="hover"
-      :focus="focus"
-      :value="value"
-      :placeholder="placeholder"
-      :errormessage="errormessage"
       :class="['input', { 'input-error': hasError }, {'input-expand': width === 'expand'}]"
-      @input="input($event.target.value)"
-      @blur="inputblur($event.target)"
-      />
-      <div role="alert" class="error" v-if="errormessage">{{ errormessage }}</div>
+      :disabled="disabled"
+      :focus="focus"
+      :errormessage="errormessage"
+      @change="change($event.target.value)"
+      @blur="inputblur($event.target)">
+        <option
+          v-for="(option, index) in options"
+          :key="index"
+          :value="option.value"
+          :disabled="option.disabled"
+          :selected="option.selected">
+          {{ option.label }}
+        </option>
+    </select>
+    <!-- type = checkbox -->
+    <fieldset v-if="isCheckbox">
+      <div v-for="(option, index) in options">
+        <input type="checkbox" :id="option.id" :name="option.label" :value="option.value" :checked="option.selected">
+        <label :for="option.id">{{ option.label | snakeToTitleCase }}</label>
+      </div>
+    </fieldset>
+    <div role="alert" class="error" v-if="errormessage">{{ errormessage }}</div>
   </component>
 </template>
 
@@ -25,40 +37,42 @@
  * formats including numbers. For longer input, use the `FormTextarea` element.
  */
 export default {
-  name: "FormInput",
-  status: "ready",
+  name: "ChoiceInput",
+  status: "prototype",
   release: "1.0.0",
   type: "Element",
   computed: {
     hasError() {
       return this.errormessage.length
     },
+    isSelect() {
+      return this.type === "select"
+    },
+    isCheckbox() {
+      return this.type === "checkbox"
+    },
+    isRadio() {
+      return this.type === "radio"
+    },
   },
   props: {
     /**
-     * The type of the form input field.
-     * `text, number, email`
+     * The type of the choice input field.
+     * `radio, checkbox, select`
      */
     type: {
       type: String,
-      default: "text",
+      default: "select",
       validator: value => {
-        return value.match(/(text|number|email)/)
+        return value.match(/(radio|checkbox|select)/)
       },
     },
     /**
-     * Text value of the form input field.
+     * The available options to check.
      */
-    value: {
-      type: String,
-      default: "",
-    },
-    /**
-     * The placeholder value for the form input field.
-     */
-    placeholder: {
-      type: String,
-      default: "",
+    options: {
+      required: true,
+      type: Array,
     },
     /**
      * The label of the form input field.
@@ -130,11 +144,23 @@ export default {
     },
   },
   methods: {
-    input(value) {
+    change(value) {
       this.$emit("change", value)
     },
     inputblur(value) {
       this.$emit("inputblur", value)
+    },
+  },
+  filters: {
+    snakeToTitleCase: function(value) {
+      if (!value) return ""
+      //ref: https://gist.github.com/kkiernan/91298079d34f0f832054
+      return value
+        .split("_")
+        .map(function(item) {
+          return item.charAt(0).toUpperCase() + item.substring(1)
+        })
+        .join(" ")
     },
   },
 }
@@ -215,11 +241,6 @@ $color-placeholder: tint($color-grayscale, 50%);
 
 <docs>
   ```jsx
-  <div>
-    <form-input label="Input" placeholder="Write your text" />
-    <form-input label=":hover" hover placeholder="Write your text" />
-    <form-input label=":focus" focus placeholder="Write your text" />
-    <form-input label="[disabled]" disabled placeholder="Disabled input" />
-  </div>
+  <choice-input id="myChoice" type="select" :options="[{label: 'opt 1', value: 'foo', selected: true}, {label: 'opt 2', value: 'bar'}]"></choice-input>
   ```
 </docs>

--- a/src/elements/InputCheckbox.vue
+++ b/src/elements/InputCheckbox.vue
@@ -1,0 +1,140 @@
+<template>
+  <component :is="wrapper" class="input">
+    <label v-if="label">{{ label }}</label>
+    <div v-for="(option, index) in options" :class="{ inline: !vertical }">
+      <input type="checkbox"
+      :id="option.id"
+      :name="label"
+      :value="option.value"
+      :checked="option.selected"
+      :disabled="option.disabled">
+      <label :for="option.id">{{ option.value }}</label>
+    </div>
+    <div role="alert" class="error" v-if="errormessage">{{ errormessage }}</div>
+  </component>
+</template>
+
+<script>
+/**
+ * Form Inputs are used to allow users to provide text input when the expected
+ * input is short. Form Input has a range of options and supports several text
+ * formats including numbers. For longer input, use the `FormTextarea` element.
+ */
+export default {
+  name: "InputCheckbox",
+  status: "prototype",
+  release: "1.0.0",
+  type: "Element",
+  computed: {
+    hasError() {
+      return this.errormessage.length
+    },
+  },
+  props: {
+    /**
+     * If true, the checkboxes will be stacked vertically. Otherwise they will be horizontal (inline).
+     */
+    vertical: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * The available options to check.
+     */
+    options: {
+      required: true,
+      type: Array,
+    },
+    /**
+     * The label of the form input field.
+     */
+    label: {
+      type: String,
+      default: "",
+    },
+    /**
+     * The validation message a user should get.
+     */
+    errormessage: {
+      type: String,
+      default: "",
+    },
+    /**
+     * The html element name used for the wrapper.
+     * `div, section`
+     */
+    wrapper: {
+      type: String,
+      default: "div",
+      validator: value => {
+        return value.match(/(div|section)/)
+      },
+    },
+    /**
+     * Unique identifier of the form input field.
+     */
+    id: {
+      type: String,
+      default: "",
+      required: true,
+    },
+    /**
+     * Whether the form input field is disabled or not.
+     * `true, false`
+     */
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * Manually trigger input field’s hover state.
+     * `true, false`
+     */
+    hover: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * Manually trigger input field’s focus state.
+     * `true, false`
+     */
+    focus: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  methods: {
+    change(value) {
+      this.$emit("change", value)
+    },
+    inputblur(value) {
+      this.$emit("inputblur", value)
+    },
+  },
+  filters: {
+    snakeToTitleCase: function(value) {
+      if (!value) return ""
+      //ref: https://gist.github.com/kkiernan/91298079d34f0f832054
+      return value
+        .split("_")
+        .map(function(item) {
+          return item.charAt(0).toUpperCase() + item.substring(1)
+        })
+        .join(" ")
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.inline {
+  display: inline-block;
+}
+</style>
+
+
+<docs>
+  ```jsx
+  <input-checkbox label="Where is my mind?" id="myChoice" :options="[{label: 'opt 1', value: 'In the clouds', selected: true}, {label: 'opt 2', value: 'I don\'t know'}]"></choice-input>
+  ```
+</docs>

--- a/src/elements/InputCheckbox.vue
+++ b/src/elements/InputCheckbox.vue
@@ -111,18 +111,6 @@ export default {
       this.$emit("inputblur", value)
     },
   },
-  filters: {
-    snakeToTitleCase: function(value) {
-      if (!value) return ""
-      //ref: https://gist.github.com/kkiernan/91298079d34f0f832054
-      return value
-        .split("_")
-        .map(function(item) {
-          return item.charAt(0).toUpperCase() + item.substring(1)
-        })
-        .join(" ")
-    },
-  },
 }
 </script>
 

--- a/src/elements/InputRadio.vue
+++ b/src/elements/InputRadio.vue
@@ -2,7 +2,7 @@
   <component :is="wrapper" class="input">
     <label v-if="label">{{ label }}</label>
     <div v-for="(option, index) in options" :class="{ inline: !vertical }">
-      <input type="checkbox"
+      <input type="radio"
       :id="option.id"
       :name="label"
       :value="option.value"
@@ -23,7 +23,7 @@
  * formats including numbers. For longer input, use the `FormTextarea` element.
  */
 export default {
-  name: "InputCheckbox",
+  name: "InputRadio",
   status: "prototype",
   release: "1.0.0",
   type: "Element",
@@ -34,14 +34,14 @@ export default {
   },
   props: {
     /**
-     * If true, the checkboxes will be stacked vertically. Otherwise they will be horizontal (inline).
+     * If true, the radio buttons will be stacked vertically. Otherwise they will be horizontal (inline).
      */
     vertical: {
       type: Boolean,
       default: false,
     },
     /**
-     * The available options to check.
+     * The available options to check. Option properties are: id, value, disabled, checked
      */
     options: {
       required: true,
@@ -125,6 +125,6 @@ export default {
 
 <docs>
   ```jsx
-  <input-checkbox label="Where is my mind?" id="myChoice" :options="[{label: 'opt 1', value: 'In the clouds', checked: true}, {label: 'opt 2', value: 'I don\'t know'}]"></choice-input>
+  <input-radio vertical=true label="Where is my mind?" id="myChoice" :options="[{label: 'opt 1', value: 'In the clouds', checked: true}, {label: 'opt 2', value: 'I don\'t know'}]"></choice-input>
   ```
 </docs>

--- a/src/elements/InputSelect.vue
+++ b/src/elements/InputSelect.vue
@@ -1,32 +1,35 @@
 <template>
   <component :is="wrapper" class="input">
     <label v-if="label">{{ label }}</label>
-    <input
+    <select
       :id="id"
-      :disabled="disabled"
-      :type="type"
-      :hover="hover"
-      :focus="focus"
-      :value="value"
-      :placeholder="placeholder"
-      :errormessage="errormessage"
       :class="['input', { 'input-error': hasError }, {'input-expand': width === 'expand'}]"
-      @input="input($event.target.value)"
-      @blur="inputblur($event.target)"
-      />
-      <div role="alert" class="error" v-if="errormessage">{{ errormessage }}</div>
+      :disabled="disabled"
+      :focus="focus"
+      :multiple="multiple"
+      :errormessage="errormessage"
+      @change="change($event.target.value)"
+      @blur="inputblur($event.target)">
+        <option
+          v-for="(option, index) in options"
+          :key="index"
+          :value="option.value"
+          :disabled="option.disabled"
+          :selected="option.selected">
+          {{ option.label }}
+        </option>
+    </select>
+    <div role="alert" class="error" v-if="errormessage">{{ errormessage }}</div>
   </component>
 </template>
 
 <script>
 /**
- * Form Inputs are used to allow users to provide text input when the expected
- * input is short. Form Input has a range of options and supports several text
- * formats including numbers. For longer input, use the `FormTextarea` element.
+ * Input Selects are used to allow users to choose among a number of options.
  */
 export default {
-  name: "FormInput",
-  status: "ready",
+  name: "InputSelect",
+  status: "prototype",
   release: "1.0.0",
   type: "Element",
   computed: {
@@ -36,32 +39,21 @@ export default {
   },
   props: {
     /**
-     * The type of the form input field.
-     * `text, number, email`
+     * Determines whether the user can select multiple options.
      */
-    type: {
-      type: String,
-      default: "text",
-      validator: value => {
-        return value.match(/(text|number|email)/)
-      },
+    multiple: {
+      type: Boolean,
+      default: false,
     },
     /**
-     * Text value of the form input field.
+     * The available options to check.
      */
-    value: {
-      type: String,
-      default: "",
+    options: {
+      required: true,
+      type: Array,
     },
     /**
-     * The placeholder value for the form input field.
-     */
-    placeholder: {
-      type: String,
-      default: "",
-    },
-    /**
-     * The label of the form input field.
+     * The label of the input select field.
      */
     label: {
       type: String,
@@ -86,7 +78,7 @@ export default {
       },
     },
     /**
-     * Unique identifier of the form input field.
+     * Unique identifier of the input select field.
      */
     id: {
       type: String,
@@ -94,7 +86,7 @@ export default {
       required: true,
     },
     /**
-     * The width of the form input field.
+     * The width of the input select field.
      * `auto, expand`
      */
     width: {
@@ -130,11 +122,23 @@ export default {
     },
   },
   methods: {
-    input(value) {
+    change(value) {
       this.$emit("change", value)
     },
     inputblur(value) {
       this.$emit("inputblur", value)
+    },
+  },
+  filters: {
+    snakeToTitleCase: function(value) {
+      if (!value) return ""
+      //ref: https://gist.github.com/kkiernan/91298079d34f0f832054
+      return value
+        .split("_")
+        .map(function(item) {
+          return item.charAt(0).toUpperCase() + item.substring(1)
+        })
+        .join(" ")
     },
   },
 }
@@ -215,11 +219,6 @@ $color-placeholder: tint($color-grayscale, 50%);
 
 <docs>
   ```jsx
-  <div>
-    <form-input label="Input" placeholder="Write your text" />
-    <form-input label=":hover" hover placeholder="Write your text" />
-    <form-input label=":focus" focus placeholder="Write your text" />
-    <form-input label="[disabled]" disabled placeholder="Disabled input" />
-  </div>
+  <input-select id="myChoice" :options="[{label: 'opt 1', value: 'foo', selected: true}, {label: 'opt 2', value: 'bar'}]"></choice-input>
   ```
 </docs>

--- a/src/elements/InputText.vue
+++ b/src/elements/InputText.vue
@@ -1,32 +1,20 @@
 <template>
   <component :is="wrapper" class="input">
     <label v-if="label">{{ label }}</label>
-    <!-- type = select -->
-    <select v-if="isSelect"
+    <input
       :id="id"
-      :class="['input', { 'input-error': hasError }, {'input-expand': width === 'expand'}]"
       :disabled="disabled"
+      :type="type"
+      :hover="hover"
       :focus="focus"
+      :value="value"
+      :placeholder="placeholder"
       :errormessage="errormessage"
-      @change="change($event.target.value)"
-      @blur="inputblur($event.target)">
-        <option
-          v-for="(option, index) in options"
-          :key="index"
-          :value="option.value"
-          :disabled="option.disabled"
-          :selected="option.selected">
-          {{ option.label }}
-        </option>
-    </select>
-    <!-- type = checkbox -->
-    <fieldset v-if="isCheckbox">
-      <div v-for="(option, index) in options">
-        <input type="checkbox" :id="option.id" :name="option.label" :value="option.value" :checked="option.selected">
-        <label :for="option.id">{{ option.label | snakeToTitleCase }}</label>
-      </div>
-    </fieldset>
-    <div role="alert" class="error" v-if="errormessage">{{ errormessage }}</div>
+      :class="['input', { 'input-error': hasError }, {'input-expand': width === 'expand'}]"
+      @input="input($event.target.value)"
+      @blur="inputblur($event.target)"
+      />
+      <div role="alert" class="error" v-if="errormessage">{{ errormessage }}</div>
   </component>
 </template>
 
@@ -37,42 +25,40 @@
  * formats including numbers. For longer input, use the `FormTextarea` element.
  */
 export default {
-  name: "ChoiceInput",
-  status: "prototype",
+  name: "InputText",
+  status: "ready",
   release: "1.0.0",
   type: "Element",
   computed: {
     hasError() {
       return this.errormessage.length
     },
-    isSelect() {
-      return this.type === "select"
-    },
-    isCheckbox() {
-      return this.type === "checkbox"
-    },
-    isRadio() {
-      return this.type === "radio"
-    },
   },
   props: {
     /**
-     * The type of the choice input field.
-     * `radio, checkbox, select`
+     * The type of the form input field.
+     * `text, number, email`
      */
     type: {
       type: String,
-      default: "select",
+      default: "text",
       validator: value => {
-        return value.match(/(radio|checkbox|select)/)
+        return value.match(/(text|number|email)/)
       },
     },
     /**
-     * The available options to check.
+     * Text value of the form input field.
      */
-    options: {
-      required: true,
-      type: Array,
+    value: {
+      type: String,
+      default: "",
+    },
+    /**
+     * The placeholder value for the form input field.
+     */
+    placeholder: {
+      type: String,
+      default: "",
     },
     /**
      * The label of the form input field.
@@ -144,23 +130,11 @@ export default {
     },
   },
   methods: {
-    change(value) {
+    input(value) {
       this.$emit("change", value)
     },
     inputblur(value) {
       this.$emit("inputblur", value)
-    },
-  },
-  filters: {
-    snakeToTitleCase: function(value) {
-      if (!value) return ""
-      //ref: https://gist.github.com/kkiernan/91298079d34f0f832054
-      return value
-        .split("_")
-        .map(function(item) {
-          return item.charAt(0).toUpperCase() + item.substring(1)
-        })
-        .join(" ")
     },
   },
 }
@@ -241,6 +215,11 @@ $color-placeholder: tint($color-grayscale, 50%);
 
 <docs>
   ```jsx
-  <choice-input id="myChoice" type="select" :options="[{label: 'opt 1', value: 'foo', selected: true}, {label: 'opt 2', value: 'bar'}]"></choice-input>
+  <div>
+    <input-text label="Input" placeholder="Write your text" />
+    <input-text label=":hover" hover placeholder="Write your text" />
+    <input-text label=":focus" focus placeholder="Write your text" />
+    <input-text label="[disabled]" disabled placeholder="Disabled input" />
+  </div>
   ```
 </docs>

--- a/src/patterns/LoginForm.vue
+++ b/src/patterns/LoginForm.vue
@@ -1,7 +1,7 @@
 <template>
   <form id="app" novalidate="true">
-    <form-input id="email" :errormessage="errormessageEmail" :value="emailValue" label="Email" @inputblur="validate($event)" placeholder="Write your text" />
-    <form-input id="pwd" :errormessage="errormessagePwd" :value="pwdValue" label="Password" @inputblur="validate($event)" placeholder="Write your text" />
+    <input-text id="email" :errormessage="errormessageEmail" :value="emailValue" label="Email" @inputblur="validate($event)" placeholder="Write your text" />
+    <input-text id="pwd" :errormessage="errormessagePwd" :value="pwdValue" label="Password" @inputblur="validate($event)" placeholder="Write your text" />
   </form>
 </template>
 

--- a/src/patterns/LoginForm.vue
+++ b/src/patterns/LoginForm.vue
@@ -1,0 +1,78 @@
+<template>
+  <form id="app" novalidate="true">
+    <form-input id="email" :errormessage="errormessageEmail" :value="emailValue" label="Email" @inputblur="validate($event)" placeholder="Write your text" />
+    <form-input id="pwd" :errormessage="errormessagePwd" :value="pwdValue" label="Password" @inputblur="validate($event)" placeholder="Write your text" />
+  </form>
+</template>
+
+<script>
+/**
+ * This example is a grouping of the _counter_ and the _svg-icon_ elements. It
+ * demonstrates how to do simple state management in a template. When the counter total
+ * reaches 5, the icon is replaced by a warning.
+ *
+ * More complex state management should be handled with Vuex.
+ */
+export default {
+  name: "LoginForm",
+  status: "Prototype",
+  release: "1.0.0",
+  type: "Pattern",
+  metaInfo: {
+    title: "Form with validation",
+    htmlAttrs: {
+      lang: "en",
+    },
+  },
+  data: function() {
+    return {
+      errormessageEmail: "",
+      errormessagePwd: "",
+      emailValue: "",
+      pwdValue: "",
+    }
+  },
+  props: {
+    /**
+     * The html element name used for the component.
+     */
+    type: {
+      type: String,
+      default: "div",
+    },
+    count: {
+      type: Number,
+      default: 0,
+    },
+  },
+  methods: {
+    validate(field) {
+      if (field.id == "email") {
+        this.emailValue = field.value
+        if (!field.value.length) {
+          this.errormessageEmail = "You need to supply an email."
+        } else {
+          this.errormessageEmail = ""
+        }
+      }
+      if (field.id == "pwd") {
+        this.pwdValue = field.value
+        if (!field.value.length) {
+          this.errormessagePwd = "You need to supply a password."
+        } else {
+          this.errormessagePwd = ""
+        }
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+</style>
+
+<docs>
+  ```jsx
+  <login-form></login-form>
+  ```
+</docs>


### PR DESCRIPTION
@axamei I'm just making a PR to highlight what I'm doing here. ChoiceInput is working as a select box, but there are a few issues with it as a checkbox, and I wonder if it makes sense to consolidate select-lists, checkboxes, and radios into a single component. It may be confusing to users to use "select=true" on a checkbox (normally would be "checked=true"). There are also some markup discrepancies. Anyway, let's discuss in the morning. 

Also might be good to relabel these to input-text, input-choice (or input-select, input-checkbox, and input-radio) so they show up in alpha order in the elements.