### PR TITLE
Adds move cursor to indicate card is active and movable

### DIFF
--- a/src/elements/Card.vue
+++ b/src/elements/Card.vue
@@ -91,6 +91,10 @@ export default {
   box-shadow: $box-shadow-small;
   color: $color-rich-black;
 
+  &:active {
+    cursor: move;
+  }
+
   &:focus,
   &-selected {
     box-shadow: $box-shadow-selected;


### PR DESCRIPTION
@sdellis i think it would be helpful to display visual indicators that a card is moving/movable. this is an example that changes the cursor, but we can add more to this.