### PR TITLE
Remove default thumbnail sizing.

### DIFF
--- a/src/elements/MediaImage.vue
+++ b/src/elements/MediaImage.vue
@@ -94,8 +94,6 @@ export default {
     background: $color-grayscale;
     display: flex;
     align-items: center;
-    height: 300px;
-    width: 300px;
 
     .lux-svg-icon,
     svg {


### PR DESCRIPTION
This improves zooming out when there aren't any thumbnails generated for
a resource. It was unable to scale before.