### PR TITLE
Adds basic checkbox option to dataTable

### DIFF
--- a/src/elements/DataTable.vue
+++ b/src/elements/DataTable.vue
@@ -21,7 +21,15 @@
             { 'lux-data-table-number': isNum(col.datatype) },
           ]"
         >
-          {{ lineItem[col.name] }}
+          <input
+            v-if="col.checkbox"
+            :id="lineItem[col.name]"
+            type="checkbox"
+            :aria-label="Object.values(lineItem).join(', ')"
+            :name="col.name"
+            :value="lineItem[col.name]"
+          />
+          <span v-else>{{ lineItem[col.name] }}</span>
         </td>
       </tr>
     </tbody>
@@ -70,7 +78,11 @@ export default {
       type: String,
     },
     /**
-     * columns defines the columns and order for which the data should be displayed.
+     * columns define the columns and order for which the data should be displayed.
+     * Columns entries can be simple strings, or they may be more complicated objects
+     * that can define `name`, `display_name`,`align`, and `checkbox` properties.
+     * Use `checkbox=true` to create a checkbox whose value is the value for that
+     * column value for the row in the table.
      * `e.g. ['name', 'email', 'age']`
      */
     columns: {
@@ -229,10 +241,17 @@ export default {
 
 <docs>
   ```jsx
-  <data-table caption="Staff Emails" summary-label="Average" :columns="['name',{ 'name': 'email', 'display_name': 'Email Address', 'align': 'center' },{ 'name': 'age', 'datatype': 'number', 'summary_value': '33'}]" :json-data="[
-    {'id': 1,'name': 'foo','email': 'foo@xxx.xxx', 'age': 42 },
-    {'id': 2,'name': 'bar','email': 'bar@xxx.xxx', 'age': 23 },
-    {'id': 3,'name': 'fez','email': 'fez@xxx.xxx', 'age': 34 },
-  ]"/>
+  <data-table caption="Staff Emails" summary-label="Average"
+    :columns="[
+      { 'name': 'id', 'display_name': 'Select Items', 'align': 'center', 'checkbox': true },
+      'name',
+      { 'name': 'email', 'display_name': 'Email Address', 'align': 'center' },
+      { 'name': 'age', 'datatype': 'number', 'summary_value': '33'}
+    ]"
+    :json-data="[
+      {'id': 1,'name': 'foo','email': 'foo@xxx.xxx', 'age': 42 },
+      {'id': 2,'name': 'bar','email': 'bar@xxx.xxx', 'age': 23 },
+      {'id': 3,'name': 'fez','email': 'fez@xxx.xxx', 'age': 34 },
+    ]"/>
   ```
 </docs>

--- a/src/elements/DataTable.vue
+++ b/src/elements/DataTable.vue
@@ -219,6 +219,82 @@ export default {
     font-size: $font-size-base;
     line-height: 1.2;
     text-align: left;
+
+    input {
+      position: relative;
+      width: auto;
+      cursor: pointer;
+
+      &:hover,
+      &:focus,
+      &:checked {
+        box-shadow: none;
+        border: 0;
+      }
+    }
+
+    input::before,
+    input::after {
+      position: absolute;
+      content: "";
+
+      /*Needed for the line-height to take effect*/
+      display: inline-block;
+    }
+
+    /*Outer box of the fake checkbox*/
+    input::before {
+      height: 16px;
+      width: 16px;
+      background-color: $color-white;
+      border: 0;
+      border-radius: $border-radius-default;
+      box-shadow: inset 0 1px 0 0 rgba($color-rich-black, 0.07),
+        0 0 0 1px tint($color-rich-black, 80%);
+      left: 0;
+      top: 4px;
+    }
+
+    /* On mouse-over, add a grey background color */
+    input:not([disabled]):hover::before {
+      box-shadow: 0 1px 5px 0 rgba($color-rich-black, 0.07), 0 0 0 1px tint($color-rich-black, 60%);
+    }
+
+    input:checked::before {
+      transition: box-shadow 0.2s ease;
+      background-color: $color-bleu-de-france;
+      box-shadow: inset 0 0 0 1px $color-bleu-de-france, 0 0 0 1px $color-bleu-de-france;
+      outline: 0;
+    }
+
+    /*Checkmark of the fake checkbox*/
+    input::after {
+      height: 5px;
+      width: 10px;
+      border-left: 2px solid $color-white;
+      border-bottom: 2px solid $color-white;
+
+      transform: rotate(-45deg);
+
+      left: 3px;
+      top: 7px;
+    }
+
+    /*Hide the checkmark by default*/
+    input[type="checkbox"]::after {
+      content: none;
+    }
+
+    /*Unhide on the checked state*/
+    input[type="checkbox"]:checked::after {
+      content: "";
+    }
+
+    /*Adding focus styles on the outer-box of the fake checkbox*/
+    input[type="checkbox"]:focus::before {
+      transition: box-shadow $duration-quickly ease;
+      box-shadow: inset 0 0 0 1px $color-bleu-de-france, 0 0 0 1px $color-bleu-de-france;
+    }
   }
 
   .lux-data-table-number {

--- a/test/unit/specs/components/__snapshots__/datatable.spec.js.snap
+++ b/test/unit/specs/components/__snapshots__/datatable.spec.js.snap
@@ -16,6 +16,11 @@ exports[`DataTable.vue has the expected html structure 1`] = `
       <th
         scope="col"
       >
+        Select Items
+      </th>
+      <th
+        scope="col"
+      >
         name
       </th>
       <th
@@ -34,71 +39,104 @@ exports[`DataTable.vue has the expected html structure 1`] = `
   <tbody>
     <tr>
       <td
+        class="lux-data-table-center"
+      >
+        <input
+          aria-label="1, foo, foo@xxx.xxx, 42"
+          id="1"
+          name="id"
+          type="checkbox"
+          value="1"
+        />
+      </td>
+      <td
         class=""
       >
-        
-        foo
-      
+        <span>
+          foo
+        </span>
       </td>
       <td
         class="lux-data-table-center"
       >
-        
-        foo@xxx.xxx
-      
+        <span>
+          foo@xxx.xxx
+        </span>
       </td>
       <td
         class="lux-data-table-number"
       >
-        
-        42
-      
+        <span>
+          42
+        </span>
       </td>
     </tr>
     <tr>
       <td
+        class="lux-data-table-center"
+      >
+        <input
+          aria-label="2, bar, bar@xxx.xxx, 23"
+          id="2"
+          name="id"
+          type="checkbox"
+          value="2"
+        />
+      </td>
+      <td
         class=""
       >
-        
-        bar
-      
+        <span>
+          bar
+        </span>
       </td>
       <td
         class="lux-data-table-center"
       >
-        
-        bar@xxx.xxx
-      
+        <span>
+          bar@xxx.xxx
+        </span>
       </td>
       <td
         class="lux-data-table-number"
       >
-        
-        23
-      
+        <span>
+          23
+        </span>
       </td>
     </tr>
     <tr>
       <td
+        class="lux-data-table-center"
+      >
+        <input
+          aria-label="3, fez, fez@xxx.xxx, 34"
+          id="3"
+          name="id"
+          type="checkbox"
+          value="3"
+        />
+      </td>
+      <td
         class=""
       >
-        
-        fez
-      
+        <span>
+          fez
+        </span>
       </td>
       <td
         class="lux-data-table-center"
       >
-        
-        fez@xxx.xxx
-      
+        <span>
+          fez@xxx.xxx
+        </span>
       </td>
       <td
         class="lux-data-table-number"
       >
-        
-        34
-      
+        <span>
+          34
+        </span>
       </td>
     </tr>
   </tbody>

--- a/test/unit/specs/components/datatable.spec.js
+++ b/test/unit/specs/components/datatable.spec.js
@@ -13,6 +13,7 @@ describe("DataTable.vue", () => {
       propsData: {
         caption: "This is a caption.",
         columns: [
+          { name: "id", display_name: "Select Items", align: "center", checkbox: true },
           "name",
           { name: "email", display_name: "Email Address", align: "center" },
           { name: "age", datatype: "number", summary_value: "33" },
@@ -33,10 +34,17 @@ describe("DataTable.vue", () => {
   })
 
   it("should render the Display Name", () => {
-    const th = wrapper.findAll("th").at(1)
+    const th = wrapper.findAll("th").at(2)
     expect(th.text()).toBe("Email Address")
-    const th2 = wrapper.findAll("th").at(0)
+    const th2 = wrapper.findAll("th").at(1)
     expect(th2.text()).toBe("name")
+  })
+
+  it("should render a checkbox when checkbox is true", () => {
+    const td1 = wrapper.find("input")
+    expect(td1.exists()).toBe(true)
+    const td2 = wrapper.findAll("td").at(1)
+    expect(td2.text()).toBe("foo")
   })
 
   it("evaluates isNum correctly", () => {
@@ -51,8 +59,8 @@ describe("DataTable.vue", () => {
 
   it("parses columns correctly", () => {
     const cols = wrapper.vm.parsedColumns
-    expect(cols[0].name).toBe("name")
-    expect(cols[1].name).toBe("email")
+    expect(cols[1].name).toBe("name")
+    expect(cols[2].name).toBe("email")
   })
 
   it("should return true for the appropriate boolean functions for alignment", () => {
@@ -70,8 +78,8 @@ describe("DataTable.vue", () => {
   })
 
   it("should remove the first column from the footerColumns, which is reserved for summaryLabel", () => {
-    expect(wrapper.vm.footerColumns.length).toBe(2)
-    expect(wrapper.vm.footerColumns[0].name).toBe("email")
+    expect(wrapper.vm.footerColumns.length).toBe(3)
+    expect(wrapper.vm.footerColumns[1].name).toBe("email")
   })
 
   it("has the expected html structure", () => {


### PR DESCRIPTION
@axamei this generates the correct markup and passes required tests, but the checkboxes don't appear correctly in the Docs site due to a CSS conflict for the `input`. I ran out of time to debug, which is why I put WIP on this. However, this code should run/display fine for Approvals using yalc (or maybe you can debug the css quickly and cut a release).

Also, the implementation is pretty basic and doesn't check to make sure checkboxes are on the first or last columns. However, I wanted to get something we could use for demo purposes this week since I will be away.