### PR TITLE
Refactors parent menuItem attribute to be children instead

### DIFF
--- a/src/patterns/DropdownMenu.vue
+++ b/src/patterns/DropdownMenu.vue
@@ -216,10 +216,34 @@ export default {
       list-style-type: none;
       margin: 0;
       padding: 0;
+      display: block;
+      width: 100%;
     }
 
     li {
       display: block;
+      width: 100%;
+    }
+
+    .lux-has-children {
+      background: none;
+    }
+
+    &.lux-show .lux-nav-children {
+      visibility: visible;
+      opacity: 1;
+      display: block;
+      position: relative;
+
+      a {
+        padding-left: 1.5rem;
+        color: $color-rich-black;
+
+        &::before {
+          content: "-";
+          padding-right: 0.5rem;
+        }
+      }
     }
 
     .lux-nav-item {
@@ -264,11 +288,10 @@ export default {
   ```jsx
   <dropdown-menu type="links" button-label="Select Options" :menu-items="[
     {name: 'Vegetable', component: 'Vegetable', disabled: true},
-    {name: 'Fruit', component: 'Fruit'},
-    {name: 'Apple', component: 'Apple', parent: 'Fruit'},
-    {name: 'Lettuce', component: 'Lettuce', parent: 'Vegetable'},
-    {name: 'Carrot', component: 'Carrot', parent: 'Vegetable'},
-    {name: 'Pear', component: 'Pear', parent: 'Fruit'},
+    {name: 'Fruit', component: 'Fruit', children: [
+      {name: 'Apple', component: 'Apple', parent: 'Fruit'},
+      {name: 'Pear', component: 'Pear', parent: 'Fruit'},
+    ]},
   ]"></dropdown-menu>
   ```
 </docs>

--- a/src/patterns/DropdownMenu.vue
+++ b/src/patterns/DropdownMenu.vue
@@ -20,10 +20,8 @@
 <script>
 /**
  * Dropdowns allows a user to select a value from a series of options. Note that a simple,
- * two-level hierarchy is possible by adding a `parent` property and setting its value
- * to the name of its parent. Note from the example that the order of the menuItem data
- * does not matter.
- * Please note that full closing tags are required.
+ * two-level hierarchy (not recursive) is possible by adding a `children` property
+ * to the item and supplying sub-items using the same syntax as the top level items.
  */
 export default {
   name: "DropdownMenu",
@@ -62,7 +60,8 @@ export default {
       },
     },
     /**
-     * The html element name used for the container
+     * An array of item (and sub-item) options for the DropdownMenu. Properties
+     * for menuItems are described in the MenuBar pattern.
      */
     menuItems: {
       type: Array,
@@ -287,10 +286,10 @@ export default {
 <docs>
   ```jsx
   <dropdown-menu type="links" button-label="Select Options" :menu-items="[
-    {name: 'Vegetable', component: 'Vegetable', disabled: true},
-    {name: 'Fruit', component: 'Fruit', children: [
-      {name: 'Apple', component: 'Apple', parent: 'Fruit'},
-      {name: 'Pear', component: 'Pear', parent: 'Fruit'},
+    {name: 'Vegetable'},
+    {name: 'Fruit', children: [
+      {name: 'Apple'},
+      {name: 'Pear'},
     ]},
   ]"></dropdown-menu>
   ```

--- a/src/patterns/LibraryHeader.vue
+++ b/src/patterns/LibraryHeader.vue
@@ -90,11 +90,16 @@ export default {
       color: $color-white;
       font-size: $font-size-large;
       font-weight: 400;
-      height: 35px;
       letter-spacing: 1px;
       line-height: 33px;
       margin: 8px 0 0;
       text-decoration: none;
+      text-align: center;
+
+      @media #{$media-query-x-large} {
+        height: 35px;
+        text-align: left;
+      }
     }
 
     @media #{$media-query-medium} {
@@ -117,6 +122,10 @@ export default {
     color: $color-white;
   }
 
+  &.dark /deep/ .lux-nav .lux-has-children {
+    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgMjkyLjQgMjkyLjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDI5Mi40IDI5Mi40OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0ZGRkZGRjt9Cjwvc3R5bGU+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0yODcsNjkuNGMtMy40LTMuNS04LjEtNS41LTEzLTUuNEgxOC40Yy01LDAtOS4zLDEuOC0xMi45LDUuNEMyLDcyLjcsMCw3Ny40LDAsODIuMmMwLDUsMS44LDkuMyw1LjQsMTIuOQoJbDEyOCwxMjcuOWMzLjYsMy42LDcuOCw1LjQsMTIuOCw1LjRzOS4yLTEuOCwxMi44LTUuNEwyODcsOTVjMy41LTMuNSw1LjQtNy44LDUuNC0xMi44cy0xLjktOS4yLTUuNS0xMi44TDI4Nyw2OS40eiIvPgo8L3N2Zz4K");
+  }
+
   /deep/ .lux-nav {
     min-width: 100px;
     top: 37px;
@@ -132,6 +141,22 @@ export default {
     &:focus {
       color: $color-white;
       text-decoration: underline;
+    }
+  }
+
+  /deep/ .lux-nav-children {
+    background: $color-white;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    border-radius: 3px;
+
+    a {
+      color: $color-rich-black;
+
+      &:hover,
+      &:focus {
+        color: $color-rich-black;
+        text-decoration: underline;
+      }
     }
   }
 
@@ -171,7 +196,9 @@ export default {
       <menu-bar type="links" :menu-items="[
           {name: 'Help', component: 'Help', href: '/help/'},
           {name: 'Feedback', component: 'Feedback', href: '/feedback/'},
-          {name: 'Your Account', component: 'Account', href: '/account/'}
+          {name: 'Your Account', component: 'Account', href: '/account/', children: [
+            {name: 'Logout', component: 'Logout', href: '/account/'}
+          ]}
         ]"
       ></menu-bar>
     </library-header>

--- a/test/unit/specs/components/__snapshots__/menuBar.spec.js.snap
+++ b/test/unit/specs/components/__snapshots__/menuBar.spec.js.snap
@@ -7,24 +7,34 @@ exports[`MenuBar.vue has the expected html structure 1`] = `
   <ul>
     <li>
       <a
-        class="lux-nav-item lux-active"
+        aria-haspopup="true"
+        class="lux-has-children lux-nav-item"
         href="/example/"
+        title="Foo"
       >
         Foo
       </a>
-    </li>
-    <li>
-      <a
-        class="lux-nav-item lux-is-child"
-        href="/example/"
+       
+      <ul
+        aria-label="submenu"
+        class="lux-nav-children"
       >
-         - Baz
-      </a>
+        <li>
+          <a
+            class="lux-nav-item"
+            href="/example/"
+            title="Baz"
+          >
+            Baz
+          </a>
+        </li>
+      </ul>
     </li>
     <li>
       <a
         class="lux-nav-item"
         href="/example/"
+        title="Bar"
       >
         Bar
       </a>

--- a/test/unit/specs/components/menuBar.spec.js
+++ b/test/unit/specs/components/menuBar.spec.js
@@ -13,9 +13,13 @@ describe("MenuBar.vue", () => {
       propsData: {
         active: "Foo",
         menuItems: [
-          { name: "Foo", component: "Foo", href: "/example/" },
+          {
+            name: "Foo",
+            component: "Foo",
+            href: "/example/",
+            children: [{ name: "Baz", component: "Baz", href: "/example/" }],
+          },
           { name: "Bar", component: "Bar", href: "/example/" },
-          { name: "Baz", component: "Baz", parent: "Foo", href: "/example/" },
         ],
       },
     })
@@ -51,12 +55,16 @@ describe("MenuBar.vue", () => {
   })
   /* eslint-disable quotes */
   it("should properly parse menu items into a hierarchy", () => {
-    const parsedItems = [
-      { name: "Foo", component: "Foo", href: "/example/" },
-      { name: " - Baz", component: "Baz", parent: "Foo", href: "/example/" },
+    const menuItemsList = [
+      {
+        name: "Foo",
+        component: "Foo",
+        href: "/example/",
+        children: [{ name: "Baz", component: "Baz", href: "/example/" }],
+      },
       { name: "Bar", component: "Bar", href: "/example/" },
     ]
-    expect(wrapper.vm.parsedMenuItems).toEqual(parsedItems)
+    expect(wrapper.vm.menuItems).toEqual(menuItemsList)
   })
 
   it("has the expected html structure", () => {


### PR DESCRIPTION
Closes #159 

@sdellis the only instance of `parent` is in the approval app's "Request type" filter. We can replace it with `children` instead.