### PR TITLE
Deduplicate logo-library title elements

### DIFF
--- a/src/elements/_LibraryLogo.vue
+++ b/src/elements/_LibraryLogo.vue
@@ -4,6 +4,7 @@
       <logo-library width="155px" height="34px" v-if="theme === 'dark'" class="full-logo" />
       <logo-library width="155px" height="34px" v-else color="#000" class="full-logo" />
       <logo-library-icon width="34px" height="34px" class="icon-only" />
+      <title id="logo-library">Princeton University Library Logo</title>
     </a>
   </component>
 </template>

--- a/src/logos/LogoLibrary.vue
+++ b/src/logos/LogoLibrary.vue
@@ -8,7 +8,6 @@
     aria-labelledby="logo-library"
     role="presentation"
   >
-    <title id="logo-library">Princeton University Library Logo</title>
     <g>
       <clipPath id="clip-path"><path d="M3 .91h90v90H3z" fill="none" /></clipPath>
       <rect width="96" height="97" rx="12.24" ry="12.24" fill="#ef7622" />

--- a/src/logos/LogoLibraryIcon.vue
+++ b/src/logos/LogoLibraryIcon.vue
@@ -8,7 +8,6 @@
     aria-labelledby="logo-library"
     role="presentation"
   >
-    <title id="logo-library">Princeton University Library Logo</title>
 
     <g>
       <path


### PR DESCRIPTION
Moves logo-library title element so that it is not duplicated in the library header. Resolves a WCAG issue.

Closes #342 
