### PR TITLE
Allows for user to set a null/empty value in LuxDatepicker 

### DIFF
--- a/src/elements/LuxDatePicker.vue
+++ b/src/elements/LuxDatePicker.vue
@@ -226,7 +226,11 @@ export default {
     },
     updateInput(value) {
       if (this.isValidFormat(value)) {
-        this.date = this.parseDate(value)
+        if (value.trim().length === 0) {
+          this.date = null
+        } else {
+          this.date = this.parseDate(value)
+        }
         this.$emit("updateInput", value)
       }
     },
@@ -244,6 +248,9 @@ export default {
       }
     },
     isValidFormat(d) {
+      if (d.trim().length === 0) {
+        return true
+      }
       let date_regex = /^\d{1,2}\/\d{1,2}\/\d{4}$/
       return date_regex.test(d)
     },

--- a/test/unit/specs/components/luxDatePicker.spec.js
+++ b/test/unit/specs/components/luxDatePicker.spec.js
@@ -24,11 +24,13 @@ describe("LuxDatePicker.vue", () => {
     expect(wrapper.vm.isValidFormat("foo")).toBe(false)
   })
 
-  it("should update the date value when a new date is input", () => {
+  it("should update the date value when a new date or a blank/null is input", () => {
     expect(wrapper.vm.date).toBe(null)
     wrapper.vm.updateInput("01/01/2019")
     const nd = new Date("2019-01-01")
     expect(wrapper.vm.date).toEqual(nd)
+    wrapper.vm.updateInput(" ")
+    expect(wrapper.vm.date).toBe(null)
   })
 
   it("should not update the date value when the input is an invalid date", () => {


### PR DESCRIPTION
The developer can set a null value, when the date field already has a set value the user cannot set it to null/blank. This PR allows that to happen.