### PR TITLE
Allows for arbitrary InputButton icons

### DIFF
--- a/src/elements/InputButton.vue
+++ b/src/elements/InputButton.vue
@@ -106,7 +106,8 @@ export default {
       default: false,
     },
     /**
-     * Indicates what icon to use.
+     * Indicates what icon to use. Values should be hyphenated and do not use the "lux-icon-" prefix.
+     * For example, instead of `lux-icon-search`, simply use `search`.
      */
     icon: {
       type: String,

--- a/src/elements/InputButton.vue
+++ b/src/elements/InputButton.vue
@@ -7,14 +7,14 @@
     @click="buttonClicked($event)"
   >
     <div v-if="variation === 'icon-prepend'" class="prepend-icon">
-      <lux-icon-base width="18" height="18" v-if="icon === 'search'" icon-name="search">
-        <lux-icon-search></lux-icon-search>
+      <lux-icon-base width="18" height="18" :icon-name="icon">
+        <component :is="iconComponent"></component>
       </lux-icon-base>
     </div>
     <slot />
     <div v-if="variation === 'icon'" class="append-icon">
-      <lux-icon-base width="18" height="18" v-if="icon === 'search'" icon-name="search">
-        <lux-icon-search></lux-icon-search>
+      <lux-icon-base width="18" height="18" :icon-name="icon">
+        <component :is="iconComponent"></component>
       </lux-icon-base>
     </div>
   </button>
@@ -111,6 +111,11 @@ export default {
     icon: {
       type: String,
       default: "",
+    },
+  },
+  computed: {
+    iconComponent() {
+      return "lux-icon-" + this.icon
     },
   },
   methods: {


### PR DESCRIPTION
Previously, when using `variant=icon` with an InputButton, you could only use the search icon. This allows for any Lux icons to be used with the icon variant.